### PR TITLE
devops : contextLoad() build

### DIFF
--- a/backEnd/src/test/java/com/quiz/ourClass/OurClassApplicationTests.java
+++ b/backEnd/src/test/java/com/quiz/ourClass/OurClassApplicationTests.java
@@ -3,11 +3,11 @@ package com.quiz.ourClass;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
+@SpringBootTest(classes = OurClassApplicationTests.class)
 class OurClassApplicationTests {
 
-	@Test
-	void contextLoads() {
-	}
+    @Test
+    void contextLoads() {
+    }
 
 }


### PR DESCRIPTION
젠킨스에서 프로젝트 빌드 시 test 코드에 contextLoads() 에러가 나서 @SpringBootTest 어노테이션에 Test 클래스 지정했습니다.