### PR TITLE
feat: LogOut API 완성

### DIFF
--- a/backEnd/build.gradle
+++ b/backEnd/build.gradle
@@ -86,6 +86,9 @@ dependencies {
 
     // ⭐ feign Client
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+
+    // ⭐ Cache
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
 }
 
 tasks.named('test') {

--- a/backEnd/src/main/java/com/quiz/ourclass/global/config/CacheConfig.java
+++ b/backEnd/src/main/java/com/quiz/ourclass/global/config/CacheConfig.java
@@ -1,0 +1,63 @@
+package com.quiz.ourclass.global.config;
+
+import java.time.Duration;
+import org.springframework.boot.autoconfigure.cache.RedisCacheManagerBuilderCustomizer;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@EnableCaching
+@Configuration
+public class CacheConfig {
+
+    /* Redis Cache 기본 설정
+     * entryTtl: 캐시 만료 시간
+     * disableCashNullValues(): 캐싱할 때 null 값을 허용하지 않는다.
+     * StringRedisSerializer(): [Key]를 직렬화 할 때 사용하는 규칙. 보통 String 형태를 많이 사용
+     * GenericJackson2JsonRedisSerializer(): [Value]를 직렬화 할 때, 사용하는 규칙 [Jackon2]를 많이 사용함.
+     * */
+    @Bean
+    public RedisCacheConfiguration redisCacheConfiguration() {
+        return RedisCacheConfiguration.defaultCacheConfig()
+            .entryTtl(Duration.ofSeconds(50))
+            .disableCachingNullValues()
+            .serializeKeysWith(
+                RedisSerializationContext.SerializationPair.fromSerializer(
+                    new StringRedisSerializer())
+            )
+            .serializeValuesWith(
+                RedisSerializationContext.SerializationPair.fromSerializer(
+                    new GenericJackson2JsonRedisSerializer())
+            );
+    }
+
+    /*
+     * 캐시 이름 별로 맞춤 세팅을 할 때 사용하는 클래스: RedisCacheManagerBuilderCustomizer
+     * OICD 캐시: ID TOKEN 유효성 검증 시 필요한 공개키 ID 목록을 받는 매소드에서 사용
+     *           해당 매소드는 일정 시간 내에 너무 많이 요청하면 요청이 차단됨.
+     *           일주일 단위를 두고 확인한다.
+     * */
+    @Bean
+    public RedisCacheManagerBuilderCustomizer redisCacheManagerBuilderCustomizer() {
+        return (builder) -> builder
+            .withCacheConfiguration("OICD",
+                RedisCacheConfiguration.defaultCacheConfig()
+                    .computePrefixWith(cacheName -> "OICD:")
+                    .entryTtl(Duration.ofDays(7))
+                    .disableCachingNullValues()
+                    .serializeKeysWith(
+                        RedisSerializationContext.SerializationPair.fromSerializer(
+                            new StringRedisSerializer())
+                    )
+                    .serializeValuesWith(
+                        RedisSerializationContext.SerializationPair.fromSerializer(
+                            new GenericJackson2JsonRedisSerializer())
+                    )
+            );
+    }
+
+}

--- a/backEnd/src/main/java/com/quiz/ourclass/global/dto/FilterResponse.java
+++ b/backEnd/src/main/java/com/quiz/ourclass/global/dto/FilterResponse.java
@@ -1,6 +1,7 @@
 package com.quiz.ourclass.global.dto;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.quiz.ourclass.global.exception.ErrorCode;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import org.springframework.stereotype.Component;
@@ -20,6 +21,10 @@ public class FilterResponse {
         response.setStatus(HttpServletResponse.SC_OK);
 
         return response;
+    }
+
+    public void error(HttpServletResponse response, ErrorCode errorCode) throws IOException {
+        response.sendError(errorCode.getStatus().value(), errorCode.getMessage());
     }
 
     public void error(HttpServletResponse response, String msg) throws IOException {

--- a/backEnd/src/main/java/com/quiz/ourclass/global/exception/ErrorCode.java
+++ b/backEnd/src/main/java/com/quiz/ourclass/global/exception/ErrorCode.java
@@ -26,6 +26,7 @@ public enum ErrorCode {
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰 입니다."),
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰 입니다."),
     CANT_FIND_REFRESH(HttpStatus.UNAUTHORIZED, "해당 토큰을 찾을 수 없습니다."),
+    ALREADY_LOGOUT(HttpStatus.UNAUTHORIZED, "이미 로그아웃한 토큰 입니다."),
 
     //s3
     FILE_NOT_FOUND(HttpStatus.NOT_FOUND, "파일이 존재하지 않습니다."),

--- a/backEnd/src/main/java/com/quiz/ourclass/global/util/RedisUtil.java
+++ b/backEnd/src/main/java/com/quiz/ourclass/global/util/RedisUtil.java
@@ -37,4 +37,9 @@ public class RedisUtil {
     public void delete(String key) {
         redisTemplate.delete(key);
     }
+
+    public boolean hasKey(String key) {
+        return Boolean.TRUE.equals(redisTemplate.hasKey(key));
+    }
+
 }

--- a/backEnd/src/main/java/com/quiz/ourclass/global/util/jwt/JwtLogOutHandler.java
+++ b/backEnd/src/main/java/com/quiz/ourclass/global/util/jwt/JwtLogOutHandler.java
@@ -1,0 +1,51 @@
+package com.quiz.ourclass.global.util.jwt;
+
+import com.quiz.ourclass.global.dto.FilterResponse;
+import com.quiz.ourclass.global.exception.ErrorCode;
+import com.quiz.ourclass.global.util.RedisUtil;
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.logout.LogoutHandler;
+
+@RequiredArgsConstructor
+public class JwtLogOutHandler implements LogoutHandler {
+
+    private final RedisUtil redisUtil;
+    private final JwtUtil jwtUtil;
+    private final FilterResponse filterResponse;
+    private final String PREFIX = "AT:";
+
+    @Override
+    public void logout(HttpServletRequest request, HttpServletResponse response,
+        Authentication authentication) {
+        String accessToken = jwtUtil.separateBearer(request.getHeader("Authorization"));
+        int valid = jwtUtil.validateToken(accessToken);
+        try {
+            if (valid == 0) {
+                Claims info = jwtUtil.getUserInfoFromToken(accessToken);
+                redisUtil.valueSet(generateKey(accessToken), info.getSubject(),
+                    Duration.ofMillis(
+                        info.getExpiration().getTime() - info.getIssuedAt().getTime()));
+                request.setAttribute("name", info.getSubject());
+
+
+            } else if (valid == 1) {
+                filterResponse.error(response, ErrorCode.EXPIRED_TOKEN);
+            } else if (valid > 1) {
+                filterResponse.error(response, ErrorCode.INVALID_TOKEN);
+            }
+        } catch (IOException e) {
+            e.getStackTrace();
+        }
+    }
+
+    private String generateKey(String accessToken) {
+        return PREFIX + accessToken;
+    }
+
+}

--- a/backEnd/src/main/java/com/quiz/ourclass/global/util/jwt/JwtLogOutSuccessHandler.java
+++ b/backEnd/src/main/java/com/quiz/ourclass/global/util/jwt/JwtLogOutSuccessHandler.java
@@ -1,0 +1,24 @@
+package com.quiz.ourclass.global.util.jwt;
+
+import com.quiz.ourclass.global.dto.FilterResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.logout.LogoutSuccessHandler;
+
+@RequiredArgsConstructor
+public class JwtLogOutSuccessHandler implements LogoutSuccessHandler {
+
+    private final FilterResponse filterResponse;
+
+    @Override
+    public void onLogoutSuccess(HttpServletRequest request, HttpServletResponse response,
+        Authentication authentication) throws IOException, ServletException {
+
+        String name = String.valueOf(request.getAttribute("name"));
+        filterResponse.ok(response, name + "로그아웃을 성공적으로 진행하였습니다.");
+    }
+}

--- a/backEnd/src/main/java/com/quiz/ourclass/global/util/jwt/JwtUtil.java
+++ b/backEnd/src/main/java/com/quiz/ourclass/global/util/jwt/JwtUtil.java
@@ -3,8 +3,8 @@ package com.quiz.ourclass.global.util.jwt;
 
 import com.quiz.ourclass.domain.member.dto.TokenDTO;
 import com.quiz.ourclass.domain.member.entity.Refresh;
-import com.quiz.ourclass.domain.member.repository.MemberRepository;
 import com.quiz.ourclass.domain.member.repository.RefreshRepository;
+import com.quiz.ourclass.global.util.RedisUtil;
 import com.quiz.ourclass.global.util.UserDetailsServiceImpl;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
@@ -63,7 +63,7 @@ public class JwtUtil {
 
     // Redis Repository 에 집어넣기 위함.
     private final RefreshRepository refreshRepository;
-    private final MemberRepository memberRepository;
+    private final RedisUtil redisUtil;
 
 
     /* A. Init 함수 -> JWT 토큰 만들기 위한 사전 준비  */
@@ -123,6 +123,10 @@ public class JwtUtil {
      * */
 
     public int validateToken(String token) {
+
+        if (redisUtil.hasKey("AT:" + token)) {
+            return -5;
+        }
         try {
             // JWT 토큰을 Parsing 하는 객체를 만들어서 객체의 파싱 매소드에 매개변수로 token 을 넣었다.
             Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);


### PR DESCRIPTION
# 💡 Issue

- #33 

# 🌱 Key changes

이번엔 커스텀 Filter 만들어서 원래 있는 녀석 자리에 대신 넣는 방식으로 안하고, 
기존에 존재하는 LogOutFilter에 Logout handler와 LogoutSuccess handler를 만들어서, 주입하는 식으로 Filter를 구현하였습니다.

## (1) 알게 된 점
Security에서 모든 에러는 인증 에러를 담당하는 Handler인 AuthorizationEntryPoint와 AccessDeniedHandler 두 개에서 다 처리한다고 생각했습니다. 하지만 이 둘은 authorizeHttpRequest에서 나는 오류만 해결하는 handler였고, 나머지는 직접 응답 객체 내용을 채워서 해결해야 되었습니다. 

## (2) 전개도 
![image](https://github.com/6QuizOnTheBlock/OurClass/assets/102154788/ec2c7727-6814-4648-bffe-eefb1a8fb645)


- [x] Logoutfilter의 handler 2개 구현 
- [x] Redis에 BlackList 만들어서 저장 
- [x] FilterResponse 구현 하여, Filter에서 예외가 터진 즉시 예외처리를 하도록 했습니다. 

# ✅ To Reviewers

# 📸 스크린샷
![image](https://github.com/6QuizOnTheBlock/OurClass/assets/102154788/a0eae704-3d3a-4277-8016-5a8776686528)
