### PR TITLE
hotFix: Java 모듈 시스템에 의한 hash 접근 차단 때문에 안되는 부분 삭제

### DIFF
--- a/backEnd/src/main/java/com/quiz/ourclass/global/config/AopConfig.java
+++ b/backEnd/src/main/java/com/quiz/ourclass/global/config/AopConfig.java
@@ -41,10 +41,7 @@ public class AopConfig {
         Object[] args = pjp.getArgs();
         StringBuilder logMsg = new StringBuilder();
         // request 값 확인
-        for (Object arg : args) {
-            logMsg.append(arg.getClass().getSimpleName()).append(" [");
-            logMsg.append(getObjectDetails(arg)).append("] ");
-        }
+
         log.info("-----------> REQUEST <Header>: {} \n <Body>: {}({}) ={}"
             , getHeaderDetail()
             , pjp.getSignature().getDeclaringTypeName()
@@ -100,7 +97,7 @@ public class AopConfig {
             HttpServletRequest request = attrs.getRequest();
             ans.append(" 요청주소: ").append(request.getRequestURL().toString())
                 .append(" 요청Method: ").append(request.getMethod())
-                .append(" IP 주소(이상하면 벤 하셈ㅋ): ").append(request.getRemoteAddr());
+                .append(" IP 주소: ").append(request.getRemoteAddr());
 
 
         } else {


### PR DESCRIPTION
# 💡 Issue

# 🌱 Key changes
- [ ] 
- [ ]

# ✅ To Reviewers

chatgpt 답변 -> 모듈 시스템에 의해 Request 파라미터 접근이 제한 되는 것 같음. 그래서 삭제함. 
---
Java Reflection 접근 제한 오류:
InaccessibleObjectException: Java Reflection을 사용하여 java.lang.String의 hash 필드에 접근하려 했으나, Java 모듈 시스템에 의해 접근이 차단되었습니다. 이는 Java 9 이상에서 강화된 캡슐화와 접근 제어 때문입니다. hash는 String 클래스의 private 필드로, 보안을 위해 외부 접근이 제한됩니다. 이 문제를 해결하려면 Reflection을 사용하여 내부 필드에 접근하지 않도록 코드를 수정하거나, 필요한 정보를 다른 방법으로 얻어야 합니다

# 📸 스크린샷

```java
2024-05-09T17:58:39.189+09:00  INFO 1 --- [nio-8080-exec-8] c.quiz.ourclass.global.util.RedisUtil    : redis insert room id : chatRoom:1
2024-05-09T17:58:46.109+09:00  INFO 1 --- [nio-8080-exec-2] c.q.o.d.chat.interceptor.ChatHandler     : StompAccessor = StompHeaderAccessor [headers={simpMessageType=MESSAGE, stompCommand=SEND, nativeHeaders={destination=[/publish/chat/message], Authorization=[eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIzMiIsIlJPTEUiOiJURUFDSEVSIiwiaWF0IjoxNzE1MjQ1MDQ1LCJleHAiOjE3MTUyODgyNDV9.AXArQkEK11r5Bp35fPN1TXg6g7yGBfEO3z0CJ_bWUwBxuQyGZ-Cq9kZvCAH2gYcAuEsENCrG5enU145poCd-1w], content-type=[application/json], content-length=[163]}, simpSessionAttributes={}, simpHeartbeat=[J@76a34149, contentType=application/json, simpSessionId=cca567e2-1526-f5ed-1712-6c8eda3d5eab, simpDestination=/publish/chat/message}]
2024-05-09T17:58:46.115+09:00 ERROR 1 --- [nboundChannel-3] .WebSocketAnnotationMethodMessageHandler : Unhandled exception from message handler method

java.lang.reflect.InaccessibleObjectException: Unable to make field private int java.lang.String.hash accessible: module java.base does not "opens java.lang" to unnamed module @123ef382
        at java.base/java.lang.reflect.AccessibleObject.throwInaccessibleObjectException(AccessibleObject.java:391) ~[na:na]
        at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:367) ~[na:na]
        at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:315) ~[na:na]
        at java.base/java.lang.reflect.Field.checkCanSetAccessible(Field.java:183) ~[na:na]
        at java.base/java.lang.reflect.Field.setAccessible(Field.java:177) ~[na:na]
        at com.quiz.ourclass.global.config.AopConfig.getObjectDetails(AopConfig.java:77) ~[!/:0.0.1-SNAPSHOT]
        at com.quiz.ourclass.global.config.AopConfig.logging(AopConfig.java:46) ~[!/:0.0.1-SNAPSHOT]
        at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103) ~[na:na]
        at java.base/java.lang.reflect.Method.invoke(Method.java:580) ~[na:na]
        at org.springframework.aop.aspectj.AbstractAspectJAdvice.invokeAdviceMethodWithGivenArgs(AbstractAspectJAdvice.java:637) ~[spring-aop-6.1.6.jar!/:6.1.6]
        at org.springframework.aop.aspectj.AbstractAspectJAdvice.invokeAdviceMethod(AbstractAspectJAdvice.java:627) ~[spring-aop-6.1.6.jar!/:6.1.6]
        at org.springframework.aop.aspectj.AspectJAroundAdvice.invoke(AspectJAroundAdvice.java:71) ~[spring-aop-6.1.6.jar!/:6.1.6]
        at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:173) ~[spring-aop-6.1.6.jar!/:6.1.6]
        at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:768) ~[spring-aop-6.1.6.jar!/:6.1.6]
        at org.springframework.aop.interceptor.ExposeInvocationInterceptor.invoke(ExposeInvocationInterceptor.java:97) ~[spring-aop-6.1.6.jar!/:6.1.6]
        at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:184) ~[spring-aop-6.1.6.jar!/:6.1.6]
        at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:768) ~[spring-aop-6.1.6.jar!/:6.1.6]
        at org.springframework.aop.framework.CglibAopProxy$DynamicAdvisedInterceptor.intercept(CglibAopProxy.java:720) ~[spring-aop-6.1.6.jar!/:6.1.6]
        at com.quiz.ourclass.domain.chat.controller.ChatController$$SpringCGLIB$$0.sendMessage(<generated>) ~[!/:0.0.1-SNAPSHOT]
        at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103) ~[na:na]
        at java.base/java.lang.reflect.Method.invoke(Method.java:580) ~[na:na]
        at org.springframework.messaging.handler.invocation.InvocableHandlerMethod.doInvoke(InvocableHandlerMethod.java:169) ~[spring-messaging-6.1.6.jar!/:6.1.6]
        at org.springframework.messaging.handler.invocation.InvocableHandlerMethod.invoke(InvocableHandlerMethod.java:119) ~[spring-messaging-6.1.6.jar!/:6.1.6]
        at org.springframework.messaging.handler.invocation.AbstractMethodMessageHandler.handleMatch(AbstractMethodMessageHandler.java:567) ~[spring-messaging-6.1.6.jar!/:6.1.6]
        at org.springframework.messaging.simp.annotation.support.SimpAnnotationMethodMessageHandler.handleMatch(SimpAnnotationMethodMessageHandler.java:529) ~[spring-messaging-6.1.6.jar!/:6.1.6]
        at org.springframework.messaging.simp.annotation.support.SimpAnnotationMethodMessageHandler.handleMatch(SimpAnnotationMethodMessageHandler.java:93) ~[spring-messaging-6.1.6.jar!/:6.1.6]
        at org.springframework.messaging.handler.invocation.AbstractMethodMessageHandler.handleMessageInternal(AbstractMethodMessageHandler.java:522) ~[spring-messaging-6.1.6.jar!/:6.1.6]
        at org.springframework.messaging.handler.invocation.AbstractMethodMessageHandler.handleMessage(AbstractMethodMessageHandler.java:457) ~[spring-messaging-6.1.6.jar!/:6.1.6]
        at org.springframework.messaging.support.ExecutorSubscribableChannel$SendTask.run(ExecutorSubscribableChannel.java:152) ~[spring-messaging-6.1.6.jar!/:6.1.6]
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) ~[na:na]
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) ~[na:na]
        at java.base/java.lang.Thread.run(Thread.java:1583) ~[na:na]

2024-05-09T17:58:46.179+09:00 ERROR 1 --- [nio-8080-exec-9] c.quiz.ourclass.global.util.jwt.JwtUtil  : JWT claims is empty, 잘못된 JWT 토큰 입니다.
2024-05-09T17:58:46.180+09:00 ERROR 1 --- [nio-8080-exec-9] c.quiz.ourclass.global.util.jwt.JwtUtil  : 관련에러: JWT String argument cannot be null or empty.
2024-05-09T17:58:46.182+09:00 ERROR 1 --- [nio-8080-exec-9] o.s.w.s.m.StompSubProtocolHandler        : Failed to send message to MessageChannel in session cca567e2-1526-f5ed-1712-6c8eda3d5eab:Failed to send message to ExecutorSubscribableChannel[clientInboundChannel]
2024-05-09T17:58:46.186+09:00 ERROR 1 --- [nio-8080-exec-9] c.quiz.ourclass.global.util.jwt.JwtUtil  : JWT claims is empty, 잘못된 JWT 토큰 입니다.
2024-05-09T17:58:46.186+09:00 ERROR 1 --- [nio-8080-exec-9] c.quiz.ourclass.global.util.jwt.JwtUtil  : 관련에러: JWT String argument cannot be null or empty.
2024-05-09T17:58:46.188+09:00  WARN 1 --- [nio-8080-exec-9] w.s.h.ExceptionWebSocketHandlerDecorator : Unhandled exception after connection closed for ExceptionWebSocketHandlerDecorator [delegate=LoggingWebSocketHandlerDecorator [delegate=SubProtocolWebSocketHandler[StompSubProtocolHandler[v10.stomp, v11.stomp, v12.stomp]]]]

org.springframework.messaging.MessageDeliveryException: Failed to send message to ExecutorSubscribableChannel[clientInboundChannel]
        at org.springframework.messaging.support.AbstractMessageChannel.send(AbstractMessageChannel.java:149) ~[spring-messaging-6.1.6.jar!/:6.1.6]
        at org.springframework.messaging.support.AbstractMessageChannel.send(AbstractMessageChannel.java:125) ~[spring-messaging-6.1.6.jar!/:6.1.6]
        at org.springframework.web.socket.messaging.StompSubProtocolHandler.afterSessionEnded(StompSubProtocolHandler.java:685) ~[spring-websocket-6.1.6.jar!/:6.1.6]
        at org.springframework.web.socket.messaging.SubProtocolWebSocketHandler.clearSession(SubProtocolWebSocketHandler.java:551) ~[spring-websocket-6.1.6.jar!/:6.1.6]
        at org.springframework.web.socket.messag
```
