### PR TITLE
fix: 게시글 상세 조회 시 멤버 Image URL 누락 되는 문제 수정

### DIFF
--- a/backEnd/src/main/java/com/quiz/ourclass/domain/board/mapper/CommentMapper.java
+++ b/backEnd/src/main/java/com/quiz/ourclass/domain/board/mapper/CommentMapper.java
@@ -14,8 +14,10 @@ import org.mapstruct.ReportingPolicy;
 @Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface CommentMapper {
 
+    @Mapping(source = "member.profileImage", target = "member.photo")
     CommentChildrenDTO commentToCommentChildrenDTO(Comment comment);
 
+    @Mapping(source = "comment.member.profileImage", target = "member.photo")
     CommentDTO commentToCommentDTOWithChildren(Comment comment, List<CommentChildrenDTO> children);
 
     @Mapping(source = "boardId", target = "post.id")

--- a/backEnd/src/main/java/com/quiz/ourclass/domain/board/mapper/PostMapper.java
+++ b/backEnd/src/main/java/com/quiz/ourclass/domain/board/mapper/PostMapper.java
@@ -19,6 +19,7 @@ import org.mapstruct.ReportingPolicy;
 public interface PostMapper {
 
     @Mapping(source = "post.author.id", target = "member.id")
+    @Mapping(source = "post.author.profileImage", target = "member.photo")
     @Mapping(source = "post.image.path", target = "path")
     @Mapping(source = "comments", target = "comments")
     PostDetailResponse postToPostDetailResponse(Post post, List<CommentDTO> comments);


### PR DESCRIPTION
# 💡 Issue
- #265 

# 🌱 Key changes
- [x] mapStruct Mapping 명시를 제대로 해주고 확인 완료했습니다.

# ✅ To Reviewers
바로 merge 합니다!

# 📸 스크린샷
![image](https://github.com/6QuizOnTheBlock/OurClass/assets/108309664/71960c44-c326-42c3-bea2-d6c14528e69c)

