### PR TITLE
feat #292: 그룹생성 시 관계테이블 그룹 횟수 카운트

### DIFF
--- a/backEnd/src/main/java/com/quiz/ourclass/domain/organization/entity/Relationship.java
+++ b/backEnd/src/main/java/com/quiz/ourclass/domain/organization/entity/Relationship.java
@@ -24,10 +24,21 @@ public class Relationship {
     Member member2;
     int relationPoint;
     int tagGreetingCount;
-    int groupCount;
+    int designGroupCount;
+    int freeGroupCount;
 
     public int updateTagGreetingCount() {
         this.tagGreetingCount += 1;
         return this.tagGreetingCount;
+    }
+
+    public int updateDesignGroupCount() {
+        this.designGroupCount += 1;
+        return this.designGroupCount;
+    }
+
+    public int updateFreeGroupCount() {
+        this.freeGroupCount += 1;
+        return this.freeGroupCount;
     }
 }

--- a/backEnd/src/main/java/com/quiz/ourclass/domain/organization/service/MemberOrgServiceImpl.java
+++ b/backEnd/src/main/java/com/quiz/ourclass/domain/organization/service/MemberOrgServiceImpl.java
@@ -85,7 +85,7 @@ public class MemberOrgServiceImpl implements MemberOrgService {
             .memberId(targetMember.getId())
             .memberName(targetMember.getName())
             .relationPoint(relationship.getRelationPoint())
-            .groupCount(relationship.getGroupCount())
+            .groupCount(relationship.getDesignGroupCount() + relationship.getFreeGroupCount())
             .tagGreetingCount(relationship.getTagGreetingCount())
             .receiveCount(receiveCount)
             .sendCount(sendCount).build();


### PR DESCRIPTION
# 💡 Issue
- feat : #292 

# 🌱 Key changes
- [x] 그룹생성 시 관계테이블 그룹 횟수 카운트
- [x] 관계 테이블 그룹횟수 비정규화 부분, 지정 그룹과 자율 그룹 따로 카운트

# ✅ To Reviewers

# 📸 스크린샷
