### PR TITLE
feat: 알림장 작성 시 FCM 전송 기능

### DIFF
--- a/backEnd/src/main/java/com/quiz/ourclass/domain/notice/entity/NoticeType.java
+++ b/backEnd/src/main/java/com/quiz/ourclass/domain/notice/entity/NoticeType.java
@@ -1,5 +1,5 @@
 package com.quiz.ourclass.domain.notice.entity;
 
 public enum NoticeType {
-    TAG, RELAY, TALK, REPORT
+    TAG, RELAY, TALK, REPORT, NOTICE
 }

--- a/backEnd/src/main/java/com/quiz/ourclass/global/util/ConstantUtil.java
+++ b/backEnd/src/main/java/com/quiz/ourclass/global/util/ConstantUtil.java
@@ -13,5 +13,8 @@ public abstract class ConstantUtil {
     public static final int RELAY_DEMERIT = -100;
     public static final int RELAY_REWARD = 50;
     public static final Long RELAY_TIMEOUT_DAY = 1L;
+    public static final String FCM_KEY_PREFIX = "FCM_";
+    public static final int MAX_RETRIES = 5; //최대 재시도 횟수
+    public static final long INITIAL_BACKOFF = 1000L; //초기 백오프 시간 (1초)
 
 }

--- a/backEnd/src/main/java/com/quiz/ourclass/global/util/FcmType.java
+++ b/backEnd/src/main/java/com/quiz/ourclass/global/util/FcmType.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 public enum FcmType {
     POST("게시글"),
     COMMENT("댓글"),
+    NOTICE("알림장"),
     ;
     private final String Type;
 }

--- a/backEnd/src/main/java/com/quiz/ourclass/global/util/FcmUtil.java
+++ b/backEnd/src/main/java/com/quiz/ourclass/global/util/FcmUtil.java
@@ -18,9 +18,6 @@ import org.springframework.stereotype.Component;
 public class FcmUtil {
 
     private final RedisUtil redisUtil;
-    private static final String FCM_KEY_PREFIX = "FCM_";
-    private static final int MAX_RETRIES = 5; //최대 재시도 횟수
-    private static final long INITIAL_BACKOFF = 1000L; //초기 백오프 시간 (1초)
 
     @Async("taskExecutor")
     public void singleFcmSend(Member member, FcmDTO fcmDTO) {
@@ -38,7 +35,7 @@ public class FcmUtil {
     }
 
     private String getFcmRedisKey(Long memberId) {
-        return FCM_KEY_PREFIX + memberId;
+        return ConstantUtil.FCM_KEY_PREFIX + memberId;
     }
 
     public Message makeMessage(String title, String body, String token) {
@@ -55,9 +52,9 @@ public class FcmUtil {
 
     private void sendMessage(Message message) {
         int attempt = 0;
-        long backoff = INITIAL_BACKOFF;
+        long backoff = ConstantUtil.INITIAL_BACKOFF;
 
-        while (attempt < MAX_RETRIES) { //지수 백오프 전략
+        while (attempt < ConstantUtil.MAX_RETRIES) { //지수 백오프 전략
             try {
                 FirebaseMessaging.getInstance().send(message);
                 log.info("FCM Send Success");
@@ -65,7 +62,7 @@ public class FcmUtil {
             } catch (FirebaseMessagingException e) {
                 log.error("FCM Send Error: {}", e.getMessage());
                 attempt++;
-                if (attempt >= MAX_RETRIES) {
+                if (attempt >= ConstantUtil.MAX_RETRIES) {
                     // 최대 재시도 횟수 도달 시 루프 종료
                     // 다른 메시지 시스템으로 알림을 전송하는 방법을 고려해볼 수 있음
                     log.error("Reached Maximum Retry Attempts");
@@ -96,5 +93,13 @@ public class FcmUtil {
 
     public String makeReportBody(String authorMember, String reportMember, String type) {
         return authorMember + " 학생이 작성한 " + type + "을" + reportMember + "학생이 신고하였습니다.";
+    }
+
+    public String makeNoticeTitle(String organizationName, String type) {
+        return organizationName + " " + type;
+    }
+
+    public String makeNoticeBody(String organizationName, String type) {
+        return organizationName + " " + type + "이 등록되었어요!!";
     }
 }


### PR DESCRIPTION
# 💡 Issue
- #297 

# 🌱 Key changes
- [x] 단체 관리자가 알림장 작성 시 해당 단체에 속한 사용자들에게 FCM 알림이 전송되도록 기능을 추가했습니다.

# ✅ To Reviewers
FCM 관련 기능과 FCM 상수에 대한 정의를 하였습니다.

# 📸 스크린샷
