### PR TITLE
feat: 답변, 질문 pub/sub, Kafka 동시성 제어

### DIFF
--- a/backEnd/build.gradle
+++ b/backEnd/build.gradle
@@ -47,10 +47,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     testImplementation 'org.springframework.security:spring-security-test'
-    compileOnly 'org.projectlombok:lombok'
     implementation group: 'org.springframework', name: 'spring-aop', version: '6.1.6'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     annotationProcessor 'org.projectlombok:lombok'
+    compileOnly 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
     // ⭐ Database

--- a/backEnd/src/main/java/com/quiz/ourclass/domain/quiz/controller/QuizController.java
+++ b/backEnd/src/main/java/com/quiz/ourclass/domain/quiz/controller/QuizController.java
@@ -38,4 +38,10 @@ public class QuizController implements QuizControllerDocs {
         @PathVariable("quizGameId") long quizGameId) {
         return ResponseEntity.ok(ResultResponse.success(quizService.getQuizUrl(quizGameId)));
     }
+
+    @GetMapping("/ranking/{quizGameId}")
+    public ResponseEntity<ResultResponse<?>> getRanking(
+        @PathVariable("quizGameId") long quizGameId) {
+        return ResponseEntity.ok(ResultResponse.success(quizService.getRanking(quizGameId)));
+    }
 }

--- a/backEnd/src/main/java/com/quiz/ourclass/domain/quiz/controller/StreamingController.java
+++ b/backEnd/src/main/java/com/quiz/ourclass/domain/quiz/controller/StreamingController.java
@@ -1,6 +1,8 @@
 package com.quiz.ourclass.domain.quiz.controller;
 
 import com.quiz.ourclass.domain.quiz.dto.GamerDTO;
+import com.quiz.ourclass.domain.quiz.dto.request.AnswerRequest;
+import com.quiz.ourclass.domain.quiz.dto.request.QuestionRequest;
 import com.quiz.ourclass.domain.quiz.service.CountdownService;
 import com.quiz.ourclass.domain.quiz.service.StreamingServiceImpl;
 import lombok.RequiredArgsConstructor;
@@ -23,15 +25,22 @@ public class StreamingController {
     // 1. gamer : [gamer List]를 point 가 높은 순으로 주는 TOPIC
 
     @MessageMapping("/gamer")
-    public void getGamer(GamerDTO message, @Header("Authorization") final String accessToken) {
+    public void getGamer(GamerDTO message) {
         log.info(message.toString());
         streamingService.sendGamer(message);
     }
 
-    // 2. answer -> 게이머들의 답변이 들어 오는 TOPIC -> point 재집계,
+    // 2. 질문 요청에 대한 응답
+    @MessageMapping("/question")
+    public void sendQuestion(QuestionRequest request) {
+        streamingService.sendQuestion(request);
+    }
+
+    // 3. answer -> 게이머들의 답변이 들어 오는 TOPIC -> point 재집계,
     @MessageMapping("/answer")
-    public void sendAnswer(final String message,
+    public void sendAnswer(final AnswerRequest request,
         @Header("Authorization") final String accessToken) {
+        streamingService.sendAnswer(request, accessToken);
     }
 
     // 3. 서버 <-> 클라이언트 시간 동기화 (React 화면 마운트 시에 서버에 요청, 서버는 남은 카운트 다운 수 전송)
@@ -42,4 +51,6 @@ public class StreamingController {
         log.info("Destination={}", sha.getDestination());
         return String.valueOf(countdownService.getCurrentCountDown());
     }
+
+
 }

--- a/backEnd/src/main/java/com/quiz/ourclass/domain/quiz/dto/request/AnswerRequest.java
+++ b/backEnd/src/main/java/com/quiz/ourclass/domain/quiz/dto/request/AnswerRequest.java
@@ -1,0 +1,16 @@
+package com.quiz.ourclass.domain.quiz.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.io.Serializable;
+
+@Schema(description = "답변 요청")
+public record AnswerRequest(
+    @Schema(description = "퀴즈게임 아이디")
+    long quizGameId,
+    @Schema(description = "퀴즈 아이디")
+    long quizId,
+    @Schema(description = "답변")
+    String answer
+) implements Serializable {
+
+}

--- a/backEnd/src/main/java/com/quiz/ourclass/domain/quiz/dto/request/QuestionRequest.java
+++ b/backEnd/src/main/java/com/quiz/ourclass/domain/quiz/dto/request/QuestionRequest.java
@@ -1,0 +1,14 @@
+package com.quiz.ourclass.domain.quiz.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.io.Serializable;
+
+@Schema(description = "현재 유저들이 풀어야할 퀴즈를 전송")
+public record QuestionRequest(
+    @Schema(description = "퀴즈 묶음의 번호")
+    int quizGameId,
+    @Schema(description = "묶음 속 현재 풀 퀴즈의 번호")
+    int id
+) implements Serializable {
+
+}

--- a/backEnd/src/main/java/com/quiz/ourclass/domain/quiz/dto/response/AnswerResponse.java
+++ b/backEnd/src/main/java/com/quiz/ourclass/domain/quiz/dto/response/AnswerResponse.java
@@ -1,0 +1,23 @@
+package com.quiz.ourclass.domain.quiz.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "퀴즈 답변")
+public record AnswerResponse(
+    @Schema(description = "퀴즈 게임 아이디")
+    long quizGameId,
+    @Schema(description = "퀴즈 아이디")
+    long quizId,
+    @Schema(description = "학생 아이디")
+    long studentId,
+    @Schema(description = "이름")
+    String name,
+    @Schema(description = "사진")
+    String photo,
+    @Schema(description = "제출 답")
+    String submit,
+    @Schema(description = "진짜 답")
+    String ans
+) {
+
+}

--- a/backEnd/src/main/java/com/quiz/ourclass/domain/quiz/dto/response/QuestionResponse.java
+++ b/backEnd/src/main/java/com/quiz/ourclass/domain/quiz/dto/response/QuestionResponse.java
@@ -1,0 +1,18 @@
+package com.quiz.ourclass.domain.quiz.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "응답")
+public record QuestionResponse(
+    long id,
+    String question,
+    String answer,
+    long point,
+    String candidate1,
+    String candidate2,
+    String candidate3,
+    String candidate4
+
+) {
+
+}

--- a/backEnd/src/main/java/com/quiz/ourclass/domain/quiz/entity/Quiz.java
+++ b/backEnd/src/main/java/com/quiz/ourclass/domain/quiz/entity/Quiz.java
@@ -11,13 +11,13 @@ import jakarta.persistence.ManyToOne;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Entity
 @Getter
 @Setter
-@RequiredArgsConstructor
+@NoArgsConstructor
 @AllArgsConstructor
 @Builder
 public class Quiz {
@@ -39,5 +39,19 @@ public class Quiz {
     @Enumerated(EnumType.STRING)
     Quiztype quiztype;
 
-
+    @Override
+    public String toString() {
+        return "Quiz{" +
+            "id=" + id +
+            ", quizGame=" + quizGame +
+            ", question='" + question + '\'' +
+            ", answer='" + answer + '\'' +
+            ", point=" + point +
+            ", candidate1='" + candidate1 + '\'' +
+            ", candidate2='" + candidate2 + '\'' +
+            ", candidate3='" + candidate3 + '\'' +
+            ", candidate4='" + candidate4 + '\'' +
+            ", quiztype=" + quiztype +
+            '}';
+    }
 }

--- a/backEnd/src/main/java/com/quiz/ourclass/domain/quiz/entity/QuizGame.java
+++ b/backEnd/src/main/java/com/quiz/ourclass/domain/quiz/entity/QuizGame.java
@@ -10,13 +10,13 @@ import jakarta.persistence.ManyToOne;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Entity
 @Getter
 @Setter
-@RequiredArgsConstructor
+@NoArgsConstructor
 @AllArgsConstructor
 @Builder
 public class QuizGame {

--- a/backEnd/src/main/java/com/quiz/ourclass/domain/quiz/mapper/QuizGameMapper.java
+++ b/backEnd/src/main/java/com/quiz/ourclass/domain/quiz/mapper/QuizGameMapper.java
@@ -11,14 +11,16 @@ import com.quiz.ourclass.global.dto.FcmDTO;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.ReportingPolicy;
+import org.springframework.transaction.annotation.Transactional;
 
+@Transactional
 @Mapper(componentModel = "spring", uses = OrganizationRepository.class, unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface QuizGameMapper {
-
 
     @Mapping(source = "organization", target = "organization")
     QuizGame toQuizGame(MakingQuizRequest makingQuizRequest, Organization organization);
 
+    @Transactional
     Quiz toQuiz(QuizGame quizGame, QuizDTO quizDTO);
 
     QuizGameDTO toQuizGameDTO(QuizGame QuizGame);

--- a/backEnd/src/main/java/com/quiz/ourclass/domain/quiz/repository/querydsl/QuizRepositoryQuerydsl.java
+++ b/backEnd/src/main/java/com/quiz/ourclass/domain/quiz/repository/querydsl/QuizRepositoryQuerydsl.java
@@ -2,6 +2,7 @@ package com.quiz.ourclass.domain.quiz.repository.querydsl;
 
 import com.quiz.ourclass.domain.member.entity.Member;
 import com.quiz.ourclass.domain.quiz.dto.GamerDTO;
+import com.quiz.ourclass.domain.quiz.dto.response.QuestionResponse;
 import java.util.List;
 import java.util.Set;
 import org.springframework.data.redis.core.ZSetOperations.TypedTuple;
@@ -13,4 +14,6 @@ public interface QuizRepositoryQuerydsl {
     public List<Member> sendUrl4Member(long quizGameId);
 
     public List<GamerDTO> getRankingList(long quizGameId, Set<TypedTuple<String>> rank);
+
+    public List<QuestionResponse> getQuiz(long quizGameId, long id);
 }

--- a/backEnd/src/main/java/com/quiz/ourclass/domain/quiz/repository/querydsl/QuizRepositoryQuerydslImpl.java
+++ b/backEnd/src/main/java/com/quiz/ourclass/domain/quiz/repository/querydsl/QuizRepositoryQuerydslImpl.java
@@ -3,11 +3,14 @@ package com.quiz.ourclass.domain.quiz.repository.querydsl;
 import static com.quiz.ourclass.domain.member.entity.QMember.member;
 import static com.quiz.ourclass.domain.organization.entity.QMemberOrganization.memberOrganization;
 import static com.quiz.ourclass.domain.organization.entity.QOrganization.organization;
+import static com.quiz.ourclass.domain.quiz.entity.QQuiz.quiz;
 import static com.quiz.ourclass.domain.quiz.entity.QQuizGame.quizGame;
 
+import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.quiz.ourclass.domain.member.entity.Member;
 import com.quiz.ourclass.domain.quiz.dto.GamerDTO;
+import com.quiz.ourclass.domain.quiz.dto.response.QuestionResponse;
 import com.quiz.ourclass.domain.quiz.entity.GamerStatus;
 import com.quiz.ourclass.global.exception.ErrorCode;
 import com.quiz.ourclass.global.exception.GlobalException;
@@ -81,5 +84,22 @@ public class QuizRepositoryQuerydslImpl implements QuizRepositoryQuerydsl {
             .toList();
     }
 
+    @Override
+    public List<QuestionResponse> getQuiz(long quizGameId, long id) {
 
+        return queryFactory.select(Projections.constructor(
+                QuestionResponse.class,
+                quiz.id,
+                quiz.question,
+                quiz.answer,
+                quiz.point,
+                quiz.candidate1,
+                quiz.candidate2,
+                quiz.candidate3,
+                quiz.candidate4
+            ))
+            .from(quiz)
+            .where(quiz.quizGame.id.eq(quizGameId))
+            .fetch();
+    }
 }

--- a/backEnd/src/main/java/com/quiz/ourclass/domain/quiz/service/QuizSend.java
+++ b/backEnd/src/main/java/com/quiz/ourclass/domain/quiz/service/QuizSend.java
@@ -1,8 +1,11 @@
 package com.quiz.ourclass.domain.quiz.service;
 
 import com.quiz.ourclass.domain.quiz.dto.GamerDTO;
+import com.quiz.ourclass.domain.quiz.dto.request.QuestionRequest;
+import com.quiz.ourclass.domain.quiz.dto.response.AnswerResponse;
 import com.quiz.ourclass.global.exception.ErrorCode;
 import com.quiz.ourclass.global.exception.GlobalException;
+import com.quiz.ourclass.global.util.ConstantUtil;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import lombok.RequiredArgsConstructor;
@@ -19,23 +22,36 @@ import org.springframework.stereotype.Component;
 public class QuizSend {
 
     private final KafkaTemplate<String, GamerDTO> gamerTemplate;
+    private final KafkaTemplate<String, QuestionRequest> questionTemplate;
+    private final KafkaTemplate<String, AnswerResponse> answerTemplate;
     private final RetryTemplate retryTemplate;
+
 
     // 1) 게이머를 Kafka 게이머 토픽으로 전송
     public void sendNewGamer(GamerDTO gamer) throws Exception {
+        sendMessage(ConstantUtil.QUIZ_GAMER, gamer, gamerTemplate);
+    }
 
+    public void sendQuestion(QuestionRequest request) throws Exception {
+        sendMessage(ConstantUtil.QUIZ_QUESTION, request, questionTemplate);
+    }
+
+    public void sendAnswer(AnswerResponse response) throws Exception {
+        sendMessage(ConstantUtil.QUIZ_ANSWER, response, answerTemplate);
+    }
+
+    private <T> void sendMessage(String topic, T message, KafkaTemplate<String, T> kafkaTemplate)
+        throws Exception {
         retryTemplate.execute((RetryCallback<Void, Exception>) context -> {
-
-            CompletableFuture<SendResult<String, GamerDTO>> future = gamerTemplate.send("gamer",
-                gamer);
+            CompletableFuture<SendResult<String, T>> future = kafkaTemplate.send(topic, message);
 
             future.whenComplete((result, e) -> {
                 if (e != null) {
-                    log.info("메세지를 보내는데 실패했습니다. 보내지 못한 메세지: {}, due to : {} ", gamer,
+                    log.info("메세지를 보내는데 실패했습니다. 보내지 못한 메세지: {}, due to : {}", message,
                         e.getMessage());
                     throw new GlobalException(ErrorCode.FAILED_TO_SENDING_MESSAGE);
                 } else {
-                    log.info("메세지 전송 성공: {}", gamer);
+                    log.info("메세지 전송 성공: {}", message);
                 }
             });
 
@@ -43,12 +59,11 @@ public class QuizSend {
                 // get()을 호출하여 비동기 작업이 완료될 때까지 대기
                 future.get();
             } catch (InterruptedException | ExecutionException e) {
+                Thread.currentThread().interrupt(); // 중요: InterruptedException 발생 시 스레드 인터럽트 상태를 복원
                 throw new GlobalException(ErrorCode.FAILED_TO_SENDING_MESSAGE);
             }
             return null;
         });
-
-        gamerTemplate.send("gamer", gamer);
     }
 
 

--- a/backEnd/src/main/java/com/quiz/ourclass/domain/quiz/service/QuizService.java
+++ b/backEnd/src/main/java/com/quiz/ourclass/domain/quiz/service/QuizService.java
@@ -1,5 +1,6 @@
 package com.quiz.ourclass.domain.quiz.service;
 
+import com.quiz.ourclass.domain.quiz.dto.GamerDTO;
 import com.quiz.ourclass.domain.quiz.dto.QuizGameDTO;
 import com.quiz.ourclass.domain.quiz.dto.request.MakingQuizRequest;
 import java.util.List;
@@ -11,4 +12,6 @@ public interface QuizService {
     public List<QuizGameDTO> getQuizList(long orgId);
 
     public String getQuizUrl(long id);
+
+    public List<GamerDTO> getRanking(long quizGameId);
 }

--- a/backEnd/src/main/java/com/quiz/ourclass/domain/quiz/service/StreamingService.java
+++ b/backEnd/src/main/java/com/quiz/ourclass/domain/quiz/service/StreamingService.java
@@ -1,8 +1,14 @@
 package com.quiz.ourclass.domain.quiz.service;
 
 import com.quiz.ourclass.domain.quiz.dto.GamerDTO;
+import com.quiz.ourclass.domain.quiz.dto.request.AnswerRequest;
+import com.quiz.ourclass.domain.quiz.dto.request.QuestionRequest;
 
 public interface StreamingService {
 
     public void sendGamer(GamerDTO message);
+
+    public void sendQuestion(QuestionRequest request);
+
+    public void sendAnswer(AnswerRequest request, String accessToken);
 }

--- a/backEnd/src/main/java/com/quiz/ourclass/domain/quiz/service/StreamingServiceImpl.java
+++ b/backEnd/src/main/java/com/quiz/ourclass/domain/quiz/service/StreamingServiceImpl.java
@@ -1,23 +1,63 @@
 package com.quiz.ourclass.domain.quiz.service;
 
+import com.quiz.ourclass.domain.member.entity.Member;
+import com.quiz.ourclass.domain.member.repository.MemberRepository;
 import com.quiz.ourclass.domain.quiz.dto.GamerDTO;
+import com.quiz.ourclass.domain.quiz.dto.request.AnswerRequest;
+import com.quiz.ourclass.domain.quiz.dto.request.QuestionRequest;
+import com.quiz.ourclass.domain.quiz.dto.response.AnswerResponse;
+import com.quiz.ourclass.domain.quiz.entity.Quiz;
+import com.quiz.ourclass.domain.quiz.repository.jpa.QuizRepository;
 import com.quiz.ourclass.global.exception.ErrorCode;
 import com.quiz.ourclass.global.exception.GlobalException;
+import com.quiz.ourclass.global.util.jwt.JwtUtil;
+import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
-import org.springframework.messaging.simp.SimpMessageSendingOperations;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class StreamingServiceImpl implements StreamingService {
 
     private final QuizSend quizSend;
-    private final SimpMessageSendingOperations template;
-    private final CountdownService countdownService;
+    private final JwtUtil jwtUtil;
+    private final MemberRepository memberRepository;
+    private final QuizRepository quizRepository;
+
 
     public void sendGamer(GamerDTO gamer) {
         try {
             quizSend.sendNewGamer(gamer);
+        } catch (Exception e) {
+            throw new GlobalException(ErrorCode.FAILED_TO_SENDING_MESSAGE);
+        }
+    }
+
+    public void sendQuestion(QuestionRequest request) {
+        try {
+            quizSend.sendQuestion(request);
+        } catch (Exception e) {
+            throw new GlobalException(ErrorCode.FAILED_TO_SENDING_MESSAGE);
+        }
+    }
+
+    public void sendAnswer(AnswerRequest request, String accessToken) {
+        Claims info = jwtUtil.getUserInfoFromToken(accessToken);
+        log.info(info.getSubject());
+        long id = Long.parseLong(info.getSubject());
+        Member member = memberRepository.findById(id)
+            .orElseThrow(() -> new GlobalException(ErrorCode.NOT_FOUND_MEMBER));
+        Quiz quiz = quizRepository.findById(request.quizId())
+            .orElseThrow(() -> new GlobalException(ErrorCode.NO_QUIZ_GAME));
+
+        AnswerResponse answerResponse = new AnswerResponse(request.quizGameId(), request.quizId(),
+            member.getId(),
+            member.getName(), member.getProfileImage(), request.answer(), quiz.getAnswer());
+
+        try {
+            quizSend.sendAnswer(answerResponse);
         } catch (Exception e) {
             throw new GlobalException(ErrorCode.FAILED_TO_SENDING_MESSAGE);
         }

--- a/backEnd/src/main/java/com/quiz/ourclass/global/config/kafka/ProducerConfig.java
+++ b/backEnd/src/main/java/com/quiz/ourclass/global/config/kafka/ProducerConfig.java
@@ -3,6 +3,8 @@ package com.quiz.ourclass.global.config.kafka;
 import com.google.common.collect.ImmutableMap;
 import com.quiz.ourclass.domain.chat.dto.Message;
 import com.quiz.ourclass.domain.quiz.dto.GamerDTO;
+import com.quiz.ourclass.domain.quiz.dto.request.QuestionRequest;
+import com.quiz.ourclass.domain.quiz.dto.response.AnswerResponse;
 import java.util.Map;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.springframework.beans.factory.annotation.Value;
@@ -59,5 +61,23 @@ public class ProducerConfig {
         return new KafkaTemplate<>(GamerProducerFactory());
     }
 
+    @Bean
+    public ProducerFactory<String, QuestionRequest> QuestionProducerFactory() {
+        return new DefaultKafkaProducerFactory<>(producerConfigurations());
+    }
 
+    @Bean
+    public KafkaTemplate<String, QuestionRequest> questionTemplate() {
+        return new KafkaTemplate<>(QuestionProducerFactory());
+    }
+
+    @Bean
+    public ProducerFactory<String, AnswerResponse> AnswerProducerFactory() {
+        return new DefaultKafkaProducerFactory<>(producerConfigurations());
+    }
+
+    @Bean
+    public KafkaTemplate<String, AnswerResponse> answerTemplate() {
+        return new KafkaTemplate<>(AnswerProducerFactory());
+    }
 }

--- a/backEnd/src/main/java/com/quiz/ourclass/global/util/ConstantUtil.java
+++ b/backEnd/src/main/java/com/quiz/ourclass/global/util/ConstantUtil.java
@@ -17,6 +17,8 @@ public abstract class ConstantUtil {
     public static final int MAX_RETRIES = 5; //최대 재시도 횟수
     public static final long INITIAL_BACKOFF = 1000L; //초기 백오프 시간 (1초)
     public static final String QUIZ_GAMER = "gamer";
+    public static final String QUIZ_QUESTION = "question";
     public static final String RANKING = "ranking";
+    public static final String QUIZ_ANSWER = "answer";
 
 }


### PR DESCRIPTION
# 💡 Issue
- #333 

# 🌱 Key changes
- [ ] gamer Topic 파티션을 4개 열었는데, 4개의 파티션이 병렬 처리를 하면서 데이터 정합성이 깨지는 일이 있었습니다. consumer에 kafka concurrency=4 로 두어서 컨슈머 개수와 파티션 개수를 맞춰주어 동시성을 제어했습니다.
- [ ] 질문에 대한 답이 오면 랭킹 점수를 수정 했습니다. 
- [ ] 랭킹 조회 API를 만들었습니다.
- [ ] 대기열에 존재할 때, 소켓이 끊긴 경우 (-> 브라우저 닫기, 강제 종료 등), 대기열 명부에서 해당 유저를 삭제했습니다.

# ✅ To Reviewers

# 📸 스크린샷
