### PR TITLE
feat: 학생 소외도 점수 계산

### DIFF
--- a/backEnd/src/main/java/com/quiz/ourclass/domain/organization/entity/MemberOrganization.java
+++ b/backEnd/src/main/java/com/quiz/ourclass/domain/organization/entity/MemberOrganization.java
@@ -44,4 +44,8 @@ public class MemberOrganization {
     public void updateRelayCount() {
         this.relayCount += 1;
     }
+
+    public void updateIsolationPoint(double isolationPoint) {
+        this.isolationPoint = isolationPoint;
+    }
 }

--- a/backEnd/src/main/java/com/quiz/ourclass/domain/organization/repository/MemberOrganizationRepository.java
+++ b/backEnd/src/main/java/com/quiz/ourclass/domain/organization/repository/MemberOrganizationRepository.java
@@ -21,4 +21,6 @@ public interface MemberOrganizationRepository extends JpaRepository<MemberOrgani
 
     Optional<MemberOrganization> findByOrganizationAndMember(Organization organization,
         Member member);
+
+    List<MemberOrganization> findAllByOrganizationOrderByMemberId(Organization organization);
 }

--- a/backEnd/src/main/java/com/quiz/ourclass/domain/organization/repository/RelationshipRepository.java
+++ b/backEnd/src/main/java/com/quiz/ourclass/domain/organization/repository/RelationshipRepository.java
@@ -1,6 +1,7 @@
 package com.quiz.ourclass.domain.organization.repository;
 
 import com.quiz.ourclass.domain.organization.entity.Organization;
+import com.quiz.ourclass.domain.member.entity.Member;
 import com.quiz.ourclass.domain.organization.entity.Relationship;
 import java.util.List;
 import java.util.Optional;
@@ -15,4 +16,6 @@ public interface RelationshipRepository extends JpaRepository<Relationship, Long
     List<Relationship> findAllByOrganization(Organization organization);
 
     List<Relationship> findAllByOrganizationIdOrderByMember1(Long orgId);
+
+    List<Relationship> findByMember1(Member member);
 }

--- a/backEnd/src/main/java/com/quiz/ourclass/global/util/scheduler/SchedulingService.java
+++ b/backEnd/src/main/java/com/quiz/ourclass/global/util/scheduler/SchedulingService.java
@@ -1,14 +1,21 @@
 package com.quiz.ourclass.global.util.scheduler;
 
+import com.quiz.ourclass.domain.organization.entity.MemberOrganization;
+import com.quiz.ourclass.domain.organization.entity.Organization;
 import com.quiz.ourclass.domain.organization.entity.Relationship;
+import com.quiz.ourclass.domain.organization.repository.MemberOrganizationRepository;
+import com.quiz.ourclass.domain.organization.repository.OrganizationRepository;
 import com.quiz.ourclass.domain.organization.repository.RelationshipRepository;
 import com.quiz.ourclass.domain.relay.repository.RelayMemberRepository;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -16,6 +23,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionTemplate;
 
+@Slf4j
 @EnableScheduling
 @RequiredArgsConstructor
 @Service
@@ -25,6 +33,8 @@ public class SchedulingService {
     private final TransactionTemplate transactionTemplate;
     private final RelationshipRepository relationshipRepository;
     private final RelayMemberRepository relayMemberRepository;
+    private final MemberOrganizationRepository memberOrganizationRepository;
+    private final OrganizationRepository organizationRepository;
 
     public <T> void scheduleTask(T target, Consumer<T> action, LocalDateTime executionTime) {
         SchedulingTask<T> task = new SchedulingTask<>(target, action, transactionTemplate);
@@ -36,14 +46,97 @@ public class SchedulingService {
     @Transactional
     @Scheduled(cron = "0 0 3 * * *")
     protected void relationShipScore() {
-        List<Relationship> relationshipList =
-            relationshipRepository.findAllByOrganizationIdOrderByMember1(1L);
+        List<Organization> organizations =
+            organizationRepository.findAll();
 
-        if (!relationshipList.isEmpty()) {
-            relationshipList.stream()
-                .map(this::updateRelationShipScore)
-                .forEach(relationshipRepository::save);
+        for (Organization organization : organizations) {
+            List<Relationship> relationshipList =
+                relationshipRepository.findAllByOrganizationIdOrderByMember1(organization.getId());
+
+            if (!relationshipList.isEmpty()) {
+                relationshipList.stream()
+                    .map(this::updateRelationShipScore)
+                    .forEach(relationshipRepository::save);
+            }
         }
+    }
+
+    @Transactional
+    @Scheduled(cron = "0 30 3 * * *")
+    protected void isolationScore() {
+        List<Organization> organizations = organizationRepository.findAll();
+
+        for (Organization organization : organizations) {
+            List<MemberOrganization> memberOrganizations =
+                memberOrganizationRepository.findAllByOrganizationOrderByMemberId(organization);
+            List<Double> allScores = new ArrayList<>();
+
+            // 전체 점수 수집
+            for (MemberOrganization member : memberOrganizations) {
+                allScores.addAll(retrieveScores(member, memberOrganizations, organization));
+            }
+
+            // 전체 점수의 평균과 표준편차 계산
+            double mean = allScores.stream()
+                .mapToDouble(Double::doubleValue)
+                .average()
+                .orElse(0.0);
+
+            double stdDev = calculateStandardDeviation(allScores, mean);
+
+            // 각 멤버의 점수 정규화 및 소외도 계산
+            for (MemberOrganization member : memberOrganizations) {
+                List<Double> scores = retrieveScores(member, memberOrganizations, organization);
+
+                List<Double> normalizedScores;
+                if (stdDev < 1e-10) { // 매우 작은 표준편차 처리
+                    // 표준편차가 0일 때, 즉 모든 점수가 같을 때
+                    // 모든 정규화 점수를 0으로 설정
+                    normalizedScores = Collections.nCopies(scores.size(), 0.0);
+                } else { // 정규화
+                    normalizedScores = scores.stream()
+                        .map(score -> (score - mean) / stdDev)
+                        .toList();
+                }
+                // 소외도 점수 도출
+                double isolationScore = normalizedScores.stream()
+                    .mapToDouble(Double::doubleValue)
+                    .average()
+                    .orElse(0.0);
+
+                updateIsolationScore(member, isolationScore);
+            }
+        }
+    }
+
+    private List<Double> retrieveScores(
+        MemberOrganization member, List<MemberOrganization> memberOrganizations,
+        Organization organization
+    ) {
+        List<Double> scores = new ArrayList<>();
+        for (MemberOrganization otherMember : memberOrganizations) {
+            if (!member.equals(otherMember)) {
+                relationshipRepository.findByOrganizationIdAndMember1IdAndMember2Id(
+                    organization.getId(),
+                    member.getMember().getId(),
+                    otherMember.getMember().getId()
+                ).ifPresent(rel -> scores.add(rel.getRelationPoint()));
+            }
+        }
+        return scores;
+    }
+
+    private double calculateStandardDeviation(List<Double> scores, double mean) {
+        double variance = scores.stream()
+            .mapToDouble(score -> Math.pow(score - mean, 2))
+            .average()
+            .orElse(0.0);
+        return Math.sqrt(variance);
+    }
+
+    private void updateIsolationScore(MemberOrganization member, double isolationScore) {
+        member.updateIsolationPoint(isolationScore);
+        memberOrganizationRepository.save(member);
     }
 
     private Relationship updateRelationShipScore(Relationship relationship) {


### PR DESCRIPTION
# 💡 Issue
- #327 

# 🌱 Key changes
- [x] Scheduler 설정
- [x] 03:30 소외도 점수 계산 로직 실행

# ✅ To Reviewers

### < 흐름 >
- 전체 학생의 관계 점수에 대한 평균, 표준편차 계산
- 개인 학생이 각 학생에 대한 점수에 대해서 전체 학생 표준 편차 값을 기준으로 점수 정규화
- 정규화된 점수들의 평균을 계산하여 해당 멤버의 소외도 점수를 도출

# 📸 스크린샷

**< 계산 전 >**

![계산 전](https://github.com/6QuizOnTheBlock/OurClass/assets/108309664/7f79addb-7439-4de7-92fd-929cf87f559c)


---


**< 계산 후 >**

![실행 후](https://github.com/6QuizOnTheBlock/OurClass/assets/108309664/25193a7b-72b3-4e08-8bdb-709d7c57bd77)

